### PR TITLE
Add comprehensive renderer and fixture unit tests plus test builders/helpers

### DIFF
--- a/DmxLib.Test/Builders/FixtureBuilder.cs
+++ b/DmxLib.Test/Builders/FixtureBuilder.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using DmxLib;
+using DmxLib.Capability;
+
+namespace DmxLib.Test.Builders
+{
+    internal sealed class FixtureBuilder
+    {
+        private readonly List<ICapability> _capabilities = [];
+        private ushort _address = 1;
+        private uint _nextChannelOffset = 1;
+
+        public FixtureBuilder Rgb()
+        {
+            _capabilities.Add(new ColorCapability
+            {
+                ChannelOffset = _nextChannelOffset,
+                Emitters =
+                [
+                    ColorCapability.EmitterColor.Red,
+                    ColorCapability.EmitterColor.Green,
+                    ColorCapability.EmitterColor.Blue,
+                ],
+            });
+            _nextChannelOffset += 3;
+            return this;
+        }
+
+        public FixtureBuilder Dimmer()
+        {
+            _capabilities.Add(new DimmerCapability { ChannelOffset = _nextChannelOffset });
+            _nextChannelOffset++;
+            return this;
+        }
+
+        public FixtureBuilder Relay()
+        {
+            _capabilities.Add(new RelayCapability { ChannelOffset = _nextChannelOffset });
+            _nextChannelOffset++;
+            return this;
+        }
+
+        public FixtureBuilder Address(ushort address)
+        {
+            _address = address;
+            return this;
+        }
+
+        public FixtureDefinition BuildDefinition()
+        {
+            return new FixtureDefinition
+            {
+                Capabilities = _capabilities.ToArray(),
+            };
+        }
+
+        public Fixture Build()
+        {
+            return new Fixture
+            {
+                Definition = BuildDefinition(),
+                Address = _address,
+            };
+        }
+    }
+}

--- a/DmxLib.Test/Builders/FixtureBuilder.cs
+++ b/DmxLib.Test/Builders/FixtureBuilder.cs
@@ -8,7 +8,7 @@ namespace DmxLib.Test.Builders
     {
         private readonly List<ICapability> _capabilities = [];
         private ushort _address = 1;
-        private uint _nextChannelOffset = 1;
+        private uint _nextChannelOffset = 0;
 
         public FixtureBuilder Rgb()
         {

--- a/DmxLib.Test/Builders/RenderStateBuilder.cs
+++ b/DmxLib.Test/Builders/RenderStateBuilder.cs
@@ -1,0 +1,40 @@
+using DmxLib.Rendering;
+using DmxLib.StatePart;
+using DmxLib.Util;
+using DmxLib;
+
+namespace DmxLib.Test.Builders
+{
+    internal sealed class RenderStateBuilder
+    {
+        private readonly RenderFrame _frame;
+
+        public RenderStateBuilder(Universe universe)
+        {
+            _frame = universe.CreateState();
+        }
+
+        public RenderStateBuilder Brightness(Fixture fixture, float brightness)
+        {
+            _frame.Get(fixture).Get<BrightnessState>().Brightness = brightness;
+            return this;
+        }
+
+        public RenderStateBuilder Color(Fixture fixture, Color color)
+        {
+            _frame.Get(fixture).Get<ColorState>().Color = color;
+            return this;
+        }
+
+        public RenderStateBuilder Relay(Fixture fixture, bool active)
+        {
+            _frame.Get(fixture).Get<RelayState>().Active = active;
+            return this;
+        }
+
+        public RenderFrame Build()
+        {
+            return _frame;
+        }
+    }
+}

--- a/DmxLib.Test/Builders/UniverseBuilder.cs
+++ b/DmxLib.Test/Builders/UniverseBuilder.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using DmxLib;
+
+namespace DmxLib.Test.Builders
+{
+    internal sealed class UniverseBuilder
+    {
+        private readonly List<Fixture> _fixtures = [];
+        private int _id = 1;
+
+        public UniverseBuilder Id(int id)
+        {
+            _id = id;
+            return this;
+        }
+
+        public UniverseBuilder WithFixture(Fixture fixture)
+        {
+            _fixtures.Add(fixture);
+            return this;
+        }
+
+        public Universe Build()
+        {
+            return new Universe
+            {
+                Id = _id,
+                Fixtures = _fixtures.ToArray(),
+            };
+        }
+    }
+}

--- a/DmxLib.Test/ColorRendererTests.cs
+++ b/DmxLib.Test/ColorRendererTests.cs
@@ -49,6 +49,67 @@ namespace DmxLib.Test
             BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2, startAddress + 3);
         }
 
+        [DataTestMethod]
+        [DataRow(-0.25f, 0)]
+        [DataRow(1.25f, 255)]
+        public void RgbWithoutDimmerClampsBrightnessOutsideNormalizedRange(float brightness, int expectedRed)
+        {
+            const int startAddress = 21;
+            var fixture = new FixtureBuilder().Rgb().Address(startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<BrightnessState>().Brightness = brightness;
+            state.Get<ColorState>().Color = TestColors.Red;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, (byte)expectedRed, Off, Off);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2);
+        }
+
+        [TestMethod]
+        public void RgbRendersOnLastThreeDmxChannels()
+        {
+            const int startAddress = 510;
+            var fixture = new FixtureBuilder().Rgb().Address(startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<BrightnessState>().Brightness = 1.0f;
+            state.Get<ColorState>().Color = TestColors.Cyan;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, Off, Full, Full);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2);
+        }
+
+        [DataTestMethod]
+        [DataRow(nameof(TestColors.Green), 0, 255, 0)]
+        [DataRow(nameof(TestColors.Blue), 0, 0, 255)]
+        [DataRow(nameof(TestColors.Yellow), 255, 255, 0)]
+        [DataRow(nameof(TestColors.Magenta), 255, 0, 255)]
+        public void RgbRendersAdditionalColors(string colorName, int expectedRed, int expectedGreen, int expectedBlue)
+        {
+            const int startAddress = 33;
+            var fixture = new FixtureBuilder().Rgb().Address(startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<BrightnessState>().Brightness = 1.0f;
+            state.Get<ColorState>().Color = colorName switch
+            {
+                nameof(TestColors.Green) => TestColors.Green,
+                nameof(TestColors.Blue) => TestColors.Blue,
+                nameof(TestColors.Yellow) => TestColors.Yellow,
+                nameof(TestColors.Magenta) => TestColors.Magenta,
+                _ => throw new AssertFailedException($"Unknown test color {colorName}."),
+            };
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, (byte)expectedRed, (byte)expectedGreen, (byte)expectedBlue);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2);
+        }
+
         [TestMethod]
         public void WhiteRendersAllRgbChannelsAtFullOutput()
         {

--- a/DmxLib.Test/ColorRendererTests.cs
+++ b/DmxLib.Test/ColorRendererTests.cs
@@ -1,0 +1,84 @@
+using DmxLib.StatePart;
+using DmxLib.Test.Builders;
+using DmxLib.Test.Helpers;
+using DmxLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DmxLib.Test
+{
+    [TestClass]
+    public sealed class ColorRendererTests
+    {
+        private const byte Off = 0;
+        private const byte Half = 127;
+        private const byte Full = 255;
+
+        [DataTestMethod]
+        [DataRow(1, 0.0f, 0)]
+        [DataRow(7, 0.25f, 63)]
+        [DataRow(13, 0.5f, 127)]
+        [DataRow(27, 0.75f, 191)]
+        [DataRow(101, 1.0f, 255)]
+        public void RgbWithoutDimmerScalesColorByBrightness(int startAddress, float brightness, int expectedRed)
+        {
+            var fixture = new FixtureBuilder().Rgb().Address((ushort)startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<BrightnessState>().Brightness = brightness;
+            state.Get<ColorState>().Color = TestColors.Red;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, (byte)expectedRed, Off, Off);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2);
+        }
+
+        [TestMethod]
+        public void RgbWithDimmerDoesNotScaleColorChannels()
+        {
+            const int startAddress = 11;
+            var fixture = new FixtureBuilder().Rgb().Dimmer().Address((ushort)startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<BrightnessState>().Brightness = 0.5f;
+            state.Get<ColorState>().Color = TestColors.Red;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, Full, Off, Off, Half);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2, startAddress + 3);
+        }
+
+        [TestMethod]
+        public void WhiteRendersAllRgbChannelsAtFullOutput()
+        {
+            const int startAddress = 3;
+            var fixture = new FixtureBuilder().Rgb().Address((ushort)startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<BrightnessState>().Brightness = 1.0f;
+            state.Get<ColorState>().Color = TestColors.White;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, Full, Full, Full);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2);
+        }
+
+        [TestMethod]
+        public void BlackRendersAllRgbChannelsAtZeroOutput()
+        {
+            const int startAddress = 9;
+            var fixture = new FixtureBuilder().Rgb().Address((ushort)startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<BrightnessState>().Brightness = 1.0f;
+            state.Get<ColorState>().Color = TestColors.Black;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, Off, Off, Off);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2);
+        }
+    }
+}

--- a/DmxLib.Test/DimmerRendererTests.cs
+++ b/DmxLib.Test/DimmerRendererTests.cs
@@ -1,0 +1,29 @@
+using DmxLib.StatePart;
+using DmxLib.Test.Builders;
+using DmxLib.Test.Helpers;
+using DmxLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DmxLib.Test
+{
+    [TestClass]
+    public sealed class DimmerRendererTests
+    {
+        [DataTestMethod]
+        [DataRow(1, 0.0f, 0)]
+        [DataRow(64, 0.5f, 127)]
+        [DataRow(200, 1.0f, 255)]
+        public void DimmerRendersBrightnessToSingleChannel(int startAddress, float brightness, int expected)
+        {
+            var fixture = new FixtureBuilder().Dimmer().Address((ushort)startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<BrightnessState>().Brightness = brightness;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, (byte)expected);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress);
+        }
+    }
+}

--- a/DmxLib.Test/FixtureDefinitionTests.cs
+++ b/DmxLib.Test/FixtureDefinitionTests.cs
@@ -16,7 +16,7 @@ namespace DmxLib.Test
 
             var numChannels = definition.NumChannels;
 
-            Assert.AreEqual((uint)6, numChannels);
+            Assert.AreEqual((uint)5, numChannels);
         }
 
         [TestMethod]

--- a/DmxLib.Test/FixtureDefinitionTests.cs
+++ b/DmxLib.Test/FixtureDefinitionTests.cs
@@ -1,0 +1,57 @@
+using System;
+using DmxLib.StatePart;
+using DmxLib.Test.Builders;
+using DmxLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DmxLib.Test
+{
+    [TestClass]
+    public sealed class FixtureDefinitionTests
+    {
+        [TestMethod]
+        public void NumChannelsReturnsCurrentChannelSpanCalculation()
+        {
+            var definition = new FixtureBuilder().Rgb().Dimmer().Relay().BuildDefinition();
+
+            var numChannels = definition.NumChannels;
+
+            Assert.AreEqual((uint)6, numChannels);
+        }
+
+        [TestMethod]
+        public void CreateStateCreatesEveryRequiredStatePart()
+        {
+            var definition = new FixtureBuilder().Rgb().Dimmer().Relay().BuildDefinition();
+
+            var state = definition.CreateState();
+
+            Assert.IsNotNull(state.Get<ColorState>());
+            Assert.IsNotNull(state.Get<BrightnessState>());
+            Assert.IsNotNull(state.Get<RelayState>());
+        }
+
+        [TestMethod]
+        public void CreateStateCreatesDuplicateRequiredStatePartsOnlyOnce()
+        {
+            var definition = new FixtureBuilder().Rgb().Dimmer().BuildDefinition();
+
+            var state = definition.CreateState();
+
+            Assert.AreSame(state.Get<BrightnessState>(), state.Get<BrightnessState>());
+            Assert.IsNotNull(state.Get<ColorState>());
+        }
+
+        [TestMethod]
+        public void CreateStateOmitsUnrequiredStateParts()
+        {
+            var definition = new FixtureBuilder().Relay().BuildDefinition();
+
+            var state = definition.CreateState();
+
+            Assert.IsNotNull(state.Get<RelayState>());
+            Assert.ThrowsException<InvalidOperationException>(() => state.Get<BrightnessState>());
+            Assert.ThrowsException<InvalidOperationException>(() => state.Get<ColorState>());
+        }
+    }
+}

--- a/DmxLib.Test/FixtureRendererTests.cs
+++ b/DmxLib.Test/FixtureRendererTests.cs
@@ -1,0 +1,46 @@
+using DmxLib.Capability;
+using DmxLib.Rendering;
+using DmxLib.StatePart;
+using DmxLib.Test.Builders;
+using DmxLib.Test.Helpers;
+using DmxLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DmxLib.Test
+{
+    [TestClass]
+    public sealed class FixtureRendererTests
+    {
+        [TestMethod]
+        public void RendersAllFixtureCapabilitiesWithResolvedRenderers()
+        {
+            const int startAddress = 17;
+            var fixture = new FixtureBuilder().Rgb().Dimmer().Relay().Address(startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<ColorState>().Color = TestColors.Red;
+            state.Get<BrightnessState>().Brightness = 0.5f;
+            state.Get<RelayState>().Active = true;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+            var renderer = RendererTestFactory.CreateFixtureRenderer();
+
+            renderer.Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, 255, 0, 0, 127, 255);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2, startAddress + 3, startAddress + 4);
+        }
+
+        [TestMethod]
+        public void ResolverFindsRendererForEachSupportedCapability()
+        {
+            var resolver = RendererTestFactory.CreateResolver();
+
+            var colorRenderer = resolver.Resolve<ColorCapability>();
+            var dimmerRenderer = resolver.Resolve<DimmerCapability>();
+            var relayRenderer = resolver.Resolve<RelayCapability>();
+
+            Assert.IsInstanceOfType(colorRenderer, typeof(ColorRenderer));
+            Assert.IsInstanceOfType(dimmerRenderer, typeof(DimmerRenderer));
+            Assert.IsInstanceOfType(relayRenderer, typeof(RelayRenderer));
+        }
+    }
+}

--- a/DmxLib.Test/FixtureRendererTests.cs
+++ b/DmxLib.Test/FixtureRendererTests.cs
@@ -1,3 +1,4 @@
+using System;
 using DmxLib.Capability;
 using DmxLib.Rendering;
 using DmxLib.StatePart;
@@ -41,6 +42,18 @@ namespace DmxLib.Test
             Assert.IsInstanceOfType(colorRenderer, typeof(ColorRenderer));
             Assert.IsInstanceOfType(dimmerRenderer, typeof(DimmerRenderer));
             Assert.IsInstanceOfType(relayRenderer, typeof(RelayRenderer));
+        }
+
+        [TestMethod]
+        public void ResolverThrowsForUnknownCapabilityType()
+        {
+            var resolver = RendererTestFactory.CreateResolver();
+
+            Assert.ThrowsException<InvalidOperationException>(() => resolver.Resolve(typeof(UnknownCapability)));
+        }
+
+        private sealed class UnknownCapability
+        {
         }
     }
 }

--- a/DmxLib.Test/FixtureStateTests.cs
+++ b/DmxLib.Test/FixtureStateTests.cs
@@ -1,0 +1,55 @@
+using System;
+using DmxLib.StatePart;
+using DmxLib.Test.Builders;
+using DmxLib.Test.Helpers;
+using DmxLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DmxLib.Test
+{
+    [TestClass]
+    public sealed class FixtureStateTests
+    {
+        [TestMethod]
+        public void GetReturnsRequestedStatePart()
+        {
+            var state = new FixtureBuilder().Rgb().Dimmer().Relay().BuildDefinition().CreateState();
+
+            var color = state.Get<ColorState>();
+            var brightness = state.Get<BrightnessState>();
+            var relay = state.Get<RelayState>();
+
+            Assert.IsNotNull(color);
+            Assert.IsNotNull(brightness);
+            Assert.IsNotNull(relay);
+        }
+
+        [TestMethod]
+        public void GetThrowsWhenStatePartIsMissing()
+        {
+            var state = new FixtureBuilder().Relay().BuildDefinition().CreateState();
+
+            Assert.ThrowsException<InvalidOperationException>(() => state.Get<ColorState>());
+        }
+
+        [TestMethod]
+        public void GetThrowsForWrongSemanticStateType()
+        {
+            var state = new FixtureBuilder().Rgb().BuildDefinition().CreateState();
+
+            Assert.ThrowsException<InvalidOperationException>(() => state.Get<RelayState>());
+        }
+
+        [TestMethod]
+        public void DefaultValuesDisableNewFixtureState()
+        {
+            var state = new FixtureBuilder().Rgb().Dimmer().Relay().BuildDefinition().CreateState();
+
+            Assert.AreEqual(0.0f, state.Get<BrightnessState>().Brightness);
+            Assert.AreEqual(TestColors.Black.R, state.Get<ColorState>().Color.R);
+            Assert.AreEqual(TestColors.Black.G, state.Get<ColorState>().Color.G);
+            Assert.AreEqual(TestColors.Black.B, state.Get<ColorState>().Color.B);
+            Assert.IsFalse(state.Get<RelayState>().Active);
+        }
+    }
+}

--- a/DmxLib.Test/Helpers/BufferAssert.cs
+++ b/DmxLib.Test/Helpers/BufferAssert.cs
@@ -1,0 +1,60 @@
+using System;
+using DmxLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DmxLib.Test.Helpers
+{
+    internal static class BufferAssert
+    {
+        public const byte Sentinel = 0x7E;
+
+        public static byte[] CreateSentinelBuffer(int length = 512)
+        {
+            var buffer = new byte[length];
+            Array.Fill(buffer, Sentinel);
+            return buffer;
+        }
+
+        public static void ContainsSlice(byte[] buffer, int oneBasedStartAddress, params byte[] expected)
+        {
+            for(var i = 0; i < expected.Length; i++)
+            {
+                Assert.AreEqual(expected[i], buffer[oneBasedStartAddress - 1 + i], $"Unexpected value at DMX channel {oneBasedStartAddress + i}.");
+            }
+        }
+
+        public static void OnlyChannelsChanged(byte[] buffer, params int[] oneBasedChannels)
+        {
+            var changed = new bool[buffer.Length];
+            foreach(var channel in oneBasedChannels)
+            {
+                changed[channel - 1] = true;
+            }
+
+            for(var i = 0; i < buffer.Length; i++)
+            {
+                if(!changed[i])
+                {
+                    Assert.AreEqual(Sentinel, buffer[i], $"DMX channel {i + 1} was changed unexpectedly.");
+                }
+            }
+        }
+
+        public static void ChannelsAreZeroExcept(byte[] buffer, params int[] oneBasedChannels)
+        {
+            var changed = new bool[buffer.Length];
+            foreach(var channel in oneBasedChannels)
+            {
+                changed[channel - 1] = true;
+            }
+
+            for(var i = 0; i < buffer.Length; i++)
+            {
+                if(!changed[i])
+                {
+                    Assert.AreEqual((byte)0, buffer[i], $"DMX channel {i + 1} was changed unexpectedly.");
+                }
+            }
+        }
+    }
+}

--- a/DmxLib.Test/Helpers/TestColors.cs
+++ b/DmxLib.Test/Helpers/TestColors.cs
@@ -1,0 +1,14 @@
+using DmxLib.Util;
+using DmxLib;
+
+namespace DmxLib.Test.Helpers
+{
+    internal static class TestColors
+    {
+        public static Color Red => Color.FromRGB(1.0, 0.0, 0.0);
+
+        public static Color White => Color.FromRGB(1.0, 1.0, 1.0);
+
+        public static Color Black => Color.FromRGB(0.0, 0.0, 0.0);
+    }
+}

--- a/DmxLib.Test/Helpers/TestColors.cs
+++ b/DmxLib.Test/Helpers/TestColors.cs
@@ -7,6 +7,16 @@ namespace DmxLib.Test.Helpers
     {
         public static Color Red => Color.FromRGB(1.0, 0.0, 0.0);
 
+        public static Color Green => Color.FromRGB(0.0, 1.0, 0.0);
+
+        public static Color Blue => Color.FromRGB(0.0, 0.0, 1.0);
+
+        public static Color Yellow => Color.FromRGB(1.0, 1.0, 0.0);
+
+        public static Color Cyan => Color.FromRGB(0.0, 1.0, 1.0);
+
+        public static Color Magenta => Color.FromRGB(1.0, 0.0, 1.0);
+
         public static Color White => Color.FromRGB(1.0, 1.0, 1.0);
 
         public static Color Black => Color.FromRGB(0.0, 0.0, 0.0);

--- a/DmxLib.Test/RegressionTests.cs
+++ b/DmxLib.Test/RegressionTests.cs
@@ -1,0 +1,44 @@
+using DmxLib.StatePart;
+using DmxLib.Test.Builders;
+using DmxLib.Test.Helpers;
+using DmxLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DmxLib.Test
+{
+    [TestClass]
+    public sealed class RegressionTests
+    {
+        [TestMethod]
+        public void RgbWithoutDimmerSimulatesDimmingInColorChannels()
+        {
+            const int startAddress = 5;
+            var fixture = new FixtureBuilder().Rgb().Address(startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<ColorState>().Color = TestColors.Red;
+            state.Get<BrightnessState>().Brightness = 0.5f;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, 127, 0, 0);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2);
+        }
+
+        [TestMethod]
+        public void RgbWithDimmerDoesNotScaleColorChannels()
+        {
+            const int startAddress = 5;
+            var fixture = new FixtureBuilder().Rgb().Dimmer().Address(startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<ColorState>().Color = TestColors.Red;
+            state.Get<BrightnessState>().Brightness = 0.5f;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, 255, 0, 0, 127);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2, startAddress + 3);
+        }
+    }
+}

--- a/DmxLib.Test/RegressionTests.cs
+++ b/DmxLib.Test/RegressionTests.cs
@@ -72,5 +72,34 @@ namespace DmxLib.Test
                 dedicatedDimmerAddress + 2,
                 dedicatedDimmerAddress + 3);
         }
+
+        [DataTestMethod]
+        [DataRow(nameof(TestColors.Red))]
+        [DataRow(nameof(TestColors.Green))]
+        [DataRow(nameof(TestColors.Blue))]
+        [DataRow(nameof(TestColors.White))]
+        [DataRow(nameof(TestColors.Magenta))]
+        public void ZeroBrightnessSuppressesRgbOutputWithoutDedicatedDimmer(string colorName)
+        {
+            const int startAddress = 70;
+            var fixture = new FixtureBuilder().Rgb().Address(startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<ColorState>().Color = colorName switch
+            {
+                nameof(TestColors.Red) => TestColors.Red,
+                nameof(TestColors.Green) => TestColors.Green,
+                nameof(TestColors.Blue) => TestColors.Blue,
+                nameof(TestColors.White) => TestColors.White,
+                nameof(TestColors.Magenta) => TestColors.Magenta,
+                _ => throw new AssertFailedException($"Unknown test color {colorName}."),
+            };
+            state.Get<BrightnessState>().Brightness = 0.0f;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, 0, 0, 0);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2);
+        }
     }
 }

--- a/DmxLib.Test/RegressionTests.cs
+++ b/DmxLib.Test/RegressionTests.cs
@@ -40,5 +40,37 @@ namespace DmxLib.Test
             BufferAssert.ContainsSlice(buffer, startAddress, 255, 0, 0, 127);
             BufferAssert.OnlyChannelsChanged(buffer, startAddress, startAddress + 1, startAddress + 2, startAddress + 3);
         }
+
+        [TestMethod]
+        public void SameBrightnessScalesRgbOnlyWhenFixtureHasNoDedicatedDimmer()
+        {
+            const int simulatedDimmerAddress = 41;
+            const int dedicatedDimmerAddress = 51;
+            var simulatedDimmerFixture = new FixtureBuilder().Rgb().Address(simulatedDimmerAddress).Build();
+            var dedicatedDimmerFixture = new FixtureBuilder().Rgb().Dimmer().Address(dedicatedDimmerAddress).Build();
+            var simulatedState = simulatedDimmerFixture.Definition.CreateState();
+            simulatedState.Get<ColorState>().Color = TestColors.Red;
+            simulatedState.Get<BrightnessState>().Brightness = 0.5f;
+            var dedicatedState = dedicatedDimmerFixture.Definition.CreateState();
+            dedicatedState.Get<ColorState>().Color = TestColors.Red;
+            dedicatedState.Get<BrightnessState>().Brightness = 0.5f;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+            var renderer = RendererTestFactory.CreateFixtureRenderer();
+
+            renderer.Render(simulatedDimmerFixture, simulatedState, buffer);
+            renderer.Render(dedicatedDimmerFixture, dedicatedState, buffer);
+
+            BufferAssert.ContainsSlice(buffer, simulatedDimmerAddress, 127, 0, 0);
+            BufferAssert.ContainsSlice(buffer, dedicatedDimmerAddress, 255, 0, 0, 127);
+            BufferAssert.OnlyChannelsChanged(
+                buffer,
+                simulatedDimmerAddress,
+                simulatedDimmerAddress + 1,
+                simulatedDimmerAddress + 2,
+                dedicatedDimmerAddress,
+                dedicatedDimmerAddress + 1,
+                dedicatedDimmerAddress + 2,
+                dedicatedDimmerAddress + 3);
+        }
     }
 }

--- a/DmxLib.Test/RelayRendererTests.cs
+++ b/DmxLib.Test/RelayRendererTests.cs
@@ -1,0 +1,28 @@
+using DmxLib.StatePart;
+using DmxLib.Test.Builders;
+using DmxLib.Test.Helpers;
+using DmxLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DmxLib.Test
+{
+    [TestClass]
+    public sealed class RelayRendererTests
+    {
+        [DataTestMethod]
+        [DataRow(1, false, 0)]
+        [DataRow(42, true, 255)]
+        public void RelayRendersActiveStateToSingleChannel(int startAddress, bool active, int expected)
+        {
+            var fixture = new FixtureBuilder().Relay().Address((ushort)startAddress).Build();
+            var state = fixture.Definition.CreateState();
+            state.Get<RelayState>().Active = active;
+            var buffer = BufferAssert.CreateSentinelBuffer();
+
+            RendererTestFactory.CreateFixtureRenderer().Render(fixture, state, buffer);
+
+            BufferAssert.ContainsSlice(buffer, startAddress, (byte)expected);
+            BufferAssert.OnlyChannelsChanged(buffer, startAddress);
+        }
+    }
+}

--- a/DmxLib.Test/RendererTestFactory.cs
+++ b/DmxLib.Test/RendererTestFactory.cs
@@ -1,0 +1,34 @@
+using DmxLib;
+using DmxLib.Rendering;
+
+namespace DmxLib.Test
+{
+    internal static class RendererTestFactory
+    {
+        public static RenderingResolver CreateResolver()
+        {
+            return new RenderingResolver
+            {
+                Renderer =
+                [
+                    new ColorRenderer(),
+                    new DimmerRenderer(),
+                    new RelayRenderer(),
+                ],
+            };
+        }
+
+        public static FixtureRenderer CreateFixtureRenderer()
+        {
+            return new FixtureRenderer
+            {
+                Resolver = CreateResolver(),
+            };
+        }
+
+        public static UniverseRenderer CreateUniverseRenderer()
+        {
+            return new UniverseRenderer(CreateFixtureRenderer());
+        }
+    }
+}

--- a/DmxLib.Test/UniverseRendererTests.cs
+++ b/DmxLib.Test/UniverseRendererTests.cs
@@ -1,0 +1,81 @@
+using DmxLib.StatePart;
+using DmxLib.Test.Builders;
+using DmxLib.Test.Helpers;
+using DmxLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DmxLib.Test
+{
+    [TestClass]
+    public sealed class UniverseRendererTests
+    {
+        [TestMethod]
+        public void RendersMultipleFixturesAtDifferentAddressesWithoutOverlappingChannels()
+        {
+            var rgbFixture = new FixtureBuilder().Rgb().Address(1).Build();
+            var dimmerFixture = new FixtureBuilder().Dimmer().Address(20).Build();
+            var relayFixture = new FixtureBuilder().Relay().Address(50).Build();
+            var universe = new UniverseBuilder()
+                .WithFixture(rgbFixture)
+                .WithFixture(dimmerFixture)
+                .WithFixture(relayFixture)
+                .Build();
+            var frame = universe.CreateState();
+            frame.Get(rgbFixture).Get<BrightnessState>().Brightness = 1.0f;
+            frame.Get(rgbFixture).Get<ColorState>().Color = TestColors.White;
+            frame.Get(dimmerFixture).Get<BrightnessState>().Brightness = 0.5f;
+            frame.Get(relayFixture).Get<RelayState>().Active = true;
+
+            var buffer = RendererTestFactory.CreateUniverseRenderer().Render(frame).ToArray();
+
+            Assert.AreEqual(512, buffer.Length);
+            BufferAssert.ContainsSlice(buffer, 1, 255, 255, 255);
+            BufferAssert.ContainsSlice(buffer, 20, 127);
+            BufferAssert.ContainsSlice(buffer, 50, 255);
+            BufferAssert.ChannelsAreZeroExcept(buffer, 1, 2, 3, 20, 50);
+        }
+
+        [TestMethod]
+        public void NewlyCreatedRenderStateRendersAllFixturesInactiveByDefault()
+        {
+            var rgbFixture = new FixtureBuilder().Rgb().Address(10).Build();
+            var dimmerFixture = new FixtureBuilder().Dimmer().Address(30).Build();
+            var relayFixture = new FixtureBuilder().Relay().Address(60).Build();
+            var universe = new UniverseBuilder()
+                .WithFixture(rgbFixture)
+                .WithFixture(dimmerFixture)
+                .WithFixture(relayFixture)
+                .Build();
+            var frame = universe.CreateState();
+
+            var buffer = RendererTestFactory.CreateUniverseRenderer().Render(frame).ToArray();
+
+            Assert.AreEqual(512, buffer.Length);
+            BufferAssert.ContainsSlice(buffer, 10, 0, 0, 0);
+            BufferAssert.ContainsSlice(buffer, 30, 0);
+            BufferAssert.ContainsSlice(buffer, 60, 0);
+            BufferAssert.ChannelsAreZeroExcept(buffer, 10, 11, 12, 30, 60);
+        }
+
+        [TestMethod]
+        public void RenderStateUsesFixtureObjectIdentityAsKey()
+        {
+            var firstFixture = new FixtureBuilder().Dimmer().Address(1).Build();
+            var secondFixture = new Fixture
+            {
+                Definition = firstFixture.Definition,
+                Address = firstFixture.Address,
+            };
+            var universe = new UniverseBuilder()
+                .WithFixture(firstFixture)
+                .WithFixture(secondFixture)
+                .Build();
+            var frame = universe.CreateState();
+
+            frame.Get(firstFixture).Get<BrightnessState>().Brightness = 0.5f;
+            frame.Get(secondFixture).Get<BrightnessState>().Brightness = 1.0f;
+
+            Assert.AreNotSame(frame.Get(firstFixture), frame.Get(secondFixture));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a comprehensive suite of unit tests to validate fixture definitions, fixture state behavior, and the rendering pipeline for color, dimmer and relay capabilities.
- Introduce small test utilities and builders to make test setup concise and consistent across tests.

### Description
- Added test builders: `FixtureBuilder`, `UniverseBuilder`, and `RenderStateBuilder` to simplify construction of fixtures, universes, and render frames. 
- Added test helpers: `BufferAssert` and `TestColors` and a `RendererTestFactory` to centralize common assertions and renderer/resolver creation. 
- Added many new MSTest test classes covering rendering and state behavior: `ColorRendererTests`, `DimmerRendererTests`, `RelayRendererTests`, `FixtureRendererTests`, `FixtureStateTests`, `FixtureDefinitionTests`, `UniverseRendererTests`, and `RegressionTests`. 
- Tests exercise channel mapping, brightness/color scaling, renderer resolution, default state values, and multi-fixture/universe rendering.

### Testing
- Ran the automated MSTest suite for the `DmxLib.Test` project using `dotnet test ./DmxLib.Test`.
- All tests in the `DmxLib.Test` project completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a416ecd6fec83259b0bcbb6d5122d93)